### PR TITLE
Add support for varnishncsa logging daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Attributes
 * `node['varnish']['storage_file']` -  Specifies either the path to the backing file or the path to a directory in which varnishd will create the backing file. Only used if using file storage. ('/var/lib/varnish/$INSTANCE/varnish_storage.bin')
 * `node['varnish']['storage_size']` -  Specifies the size of the backing file or max memory allocation.  The size is assumed to be in bytes, unless followed by one of the following suffixes: K,k,M,m,G,g,T,g,% (1G)
 * `node['varnish']['log_daemon']` -  Specifies if the system `varnishlog` daemon dumping all the varnish logs into `/var/log/varnish/varnish.log` should be enabled. (true)
+* `node['varnish']['ncsa_daemon']` -  Specifies if the system `varnishncsa` daemon dumping apache style logs into `/var/log/varnish/varnishncsa.log` should be enabled. (true)
 * `node['varnish']['parameters']` = Set the parameter specified by param to the specified value. See Run-Time Parameters for a list of parameters. This option can be used multiple times to specifymultiple parameters.
 
 If you don't specify your own vcl_conf file, then these attributes are used in the cookbook `default.vcl` template:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['varnish']['storage'] = 'file'
 default['varnish']['storage_file'] = '/var/lib/varnish/$INSTANCE_varnish_storage.bin'
 default['varnish']['storage_size'] = '1G'
 default['varnish']['log_daemon'] = true
+default['varnish']['ncsa_daemon'] = true
 default['varnish']['use_default_repo'] = true
 
 default['varnish']['backend_host'] = 'localhost'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,3 +50,8 @@ service 'varnishlog' do
   supports restart: true, reload: true
   action node['varnish']['log_daemon'] ? %w(enable start) : %w(disable stop)
 end
+
+service 'varnishncsa' do
+  supports restart: true, reload: true
+  action node['varnish']['ncsa_daemon'] ? %w(enable start) : %w(disable stop)
+end


### PR DESCRIPTION
I strongly prefer less verbose varnishncsa logs than varnishlog.
This request will add support for varnishncsa daemon from within cookbook (exactly like for varnishlog).