### PR TITLE
Add ncsa and varnish logs with logrotate.d configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,15 @@ Attributes
 * `node['varnish']['storage']` - The storage type used ('file')
 * `node['varnish']['storage_file']` -  Specifies either the path to the backing file or the path to a directory in which varnishd will create the backing file. Only used if using file storage. ('/var/lib/varnish/$INSTANCE/varnish_storage.bin')
 * `node['varnish']['storage_size']` -  Specifies the size of the backing file or max memory allocation.  The size is assumed to be in bytes, unless followed by one of the following suffixes: K,k,M,m,G,g,T,g,% (1G)
-* `node['varnish']['log_daemon']` -  Specifies if the system `varnishlog` daemon dumping all the varnish logs into `/var/log/varnish/varnish.log` should be enabled. (true)
-* `node['varnish']['parameters']` = Set the parameter specified by param to the specified value. See Run-Time Parameters for a list of parameters. This option can be used multiple times to specifymultiple parameters.
+* `node['varnish']['log_daemon']` - Specifies if the system `varnishlog` daemon dumping all the varnish logs into node['varnish']['log_file'] should be enabled. (false)
+* `node['varnish']['log_file']` - Path to the log file (/var/log/varnish/varnish.log)
+* `node['varnish']['log_pid_file']` - Path to the pid file (/var/run/varnishlog.pid)
+* `node['varnish']['ncsa_daemon']` - Specifies if the system `varnishncsa` daemon dumping apache style logs into node['varnish']['ncsa_file'] should be enabled. (true)
+* `node['varnish']['ncsa_file']` - Path to the ncsa log file (/var/log/varnish/varnishncsa.log)
+* `node['varnish']['ncsa_pid_file']` - Path to the ncsa pid file (/var/run/varnishncsa.pid)
+* `node['varnish']['ncsa_format']` - Specifies the ncsa log format ('%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"')
+* `node['varnish']['logrotate.d_path']` - Path to the varnish log rotation configuration (/etc/logrotate.d/varnish)
+* `node['varnish']['parameters']` - Set the parameter specified by param to the specified value. See Run-Time Parameters for a list of parameters. This option can be used multiple times to specifymultiple parameters.
 
 If you don't specify your own vcl_conf file, then these attributes are used in the cookbook `default.vcl` template:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,14 @@ default['varnish']['parameters']['thread_pool_timeout'] = '300'
 default['varnish']['storage'] = 'file'
 default['varnish']['storage_file'] = '/var/lib/varnish/$INSTANCE_varnish_storage.bin'
 default['varnish']['storage_size'] = '1G'
-default['varnish']['log_daemon'] = true
+default['varnish']['log_daemon'] = false
+default['varnish']['log_file'] = '/var/log/varnish/varnish.log'
+default['varnish']['log_pid_file'] = '/var/run/varnishlog.pid'
+default['varnish']['ncsa_daemon'] = true
+default['varnish']['ncsa_file'] = '/var/log/varnish/varnishncsa.log'
+default['varnish']['ncsa_pid_file'] = '/var/run/varnishncsa.pid'
+default['varnish']['ncsa_format'] = '%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"'
+default['varnish']['logrotate.d_path'] = '/etc/logrotate.d/varnish'
 default['varnish']['use_default_repo'] = true
 
 default['varnish']['backend_host'] = 'localhost'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,7 +39,7 @@ default['varnish']['ncsa_daemon'] = true
 default['varnish']['ncsa_file'] = '/var/log/varnish/varnishncsa.log'
 default['varnish']['ncsa_pid_file'] = '/var/run/varnishncsa.pid'
 default['varnish']['ncsa_format'] = '%h %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"'
-default['varnish']['logrotate.d_path'] = '/etc/logrotate.d/varnish'
+default['varnish']['logrotate.d_path'] = '/etc/logrotate.d'
 default['varnish']['use_default_repo'] = true
 
 default['varnish']['backend_host'] = 'localhost'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,11 +57,12 @@ template "#{node['varnish']['default']}ncsa" do
   notifies 'reload', 'service[varnishncsa]', 'immediately'
 end
 
-template node['varnish']['logrotate.d_path'] do
+template "#{node['varnish']['logrotate.d_path']}/varnish" do
   source 'logrotate.erb'
   owner 'root'
   group 'root'
   mode 0644
+  only_if do File.exists?(node['varnish']['logrotate.d_path']) end
 end
 
 service 'varnish' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,29 @@ template node['varnish']['default'] do
   notifies 'restart', 'service[varnish]'
 end
 
+template "#{node['varnish']['default']}log" do
+  source 'log_default.erb'
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies 'reload', 'service[varnishlog]', 'immediately'
+end
+
+template "#{node['varnish']['default']}ncsa" do
+  source 'ncsa_default.erb'
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies 'reload', 'service[varnishncsa]', 'immediately'
+end
+
+template node['varnish']['logrotate.d_path'] do
+  source 'logrotate.erb'
+  owner 'root'
+  group 'root'
+  mode 0644
+end
+
 service 'varnish' do
   supports restart: true, reload: true
   action %w(enable start)
@@ -49,4 +72,9 @@ end
 service 'varnishlog' do
   supports restart: true, reload: true
   action node['varnish']['log_daemon'] ? %w(enable start) : %w(disable stop)
+end
+
+service 'varnishncsa' do
+  supports restart: true, reload: true
+  action node['varnish']['ncsa_daemon'] ? %w(enable start) : %w(disable stop)
 end

--- a/templates/default/log_default.erb
+++ b/templates/default/log_default.erb
@@ -1,0 +1,20 @@
+# Configuration file for varnishncsa
+#
+# /etc/init.d/varnishlog variable $DAEMON_OPTS will be overridden
+# by the variable which will be set from this shell script fragment.
+#
+
+# Overriding the logfile and pidfile variables
+logfile="<%= node['varnish']['log_file'] %>"
+pidfile="<%= node['varnish']['log_pid_file'] %>"
+
+# Default varnish instance name is the local nodename.  Can be overridden with
+# the -n switch, to have more instances on a single server.
+INSTANCE=<%= node['varnish']['instance'] %>
+
+# Override the Daemon options
+DAEMON_OPTS="-a -w $logfile -D -P $pidfile \
+             <%- if node['platform_family'] == 'debian' %>
+              -n $INSTANCE \
+             <%- end %>
+			"

--- a/templates/default/log_default.erb
+++ b/templates/default/log_default.erb
@@ -17,4 +17,4 @@ DAEMON_OPTS="-a -w $logfile -D -P $pidfile \
              <%- if node['platform_family'] == 'debian' %>
               -n $INSTANCE \
              <%- end %>
-			"
+            "

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -1,0 +1,22 @@
+<%= node['varnish']['log_file'] %> {
+    daily
+    rotate 7
+    missingok
+    notifempty
+    compress
+    delaycompress
+    postrotate
+        /bin/kill -HUP `cat <%= node['varnish']['log_pid_file'] %> 2>/dev/null` 2> /dev/null || true
+    endscript
+}
+<%= node['varnish']['ncsa_file'] %> {
+    daily
+    rotate 7
+    missingok
+    notifempty
+    compress
+    delaycompress
+    postrotate
+        /bin/kill -HUP `cat <%= node['varnish']['ncsa_pid_file'] %> 2>/dev/null` 2> /dev/null || true
+    endscript
+}

--- a/templates/default/ncsa_default.erb
+++ b/templates/default/ncsa_default.erb
@@ -1,0 +1,20 @@
+# Configuration file for varnishncsa
+#
+# /etc/init.d/varnishncsa variable $DAEMON_OPTS will be overridden
+# by the variable which will be set from this shell script fragment.
+#
+
+# Overriding the logfile and pidfile variables
+logfile="<%= node['varnish']['ncsa_file'] %>"
+pidfile="<%= node['varnish']['ncsa_pid_file'] %>"
+
+# Default varnish instance name is the local nodename.  Can be overridden with
+# the -n switch, to have more instances on a single server.
+INSTANCE=<%= node['varnish']['instance'] %>
+
+# Override the Daemon options
+DAEMON_OPTS="-a -w $logfile -D -P $pidfile \
+             <%- if node['platform_family'] == 'debian' %>
+              -n $INSTANCE \
+             <%- end %>
+			  -F '<%= node['varnish']['ncsa_format'] %>'"

--- a/templates/default/ncsa_default.erb
+++ b/templates/default/ncsa_default.erb
@@ -15,6 +15,6 @@ INSTANCE=<%= node['varnish']['instance'] %>
 # Override the Daemon options
 DAEMON_OPTS="-a -w $logfile -D -P $pidfile \
              <%- if node['platform_family'] == 'debian' %>
-              -n $INSTANCE \
+             -n $INSTANCE \
              <%- end %>
-			  -F '<%= node['varnish']['ncsa_format'] %>'"
+             -F '<%= node['varnish']['ncsa_format'] %>'"


### PR DESCRIPTION
Based on gagor pull request (https://github.com/gagor/varnish/commit/0a9969f2854fe6fedfe785e56226682d20008a1e)

Please note that I've changed the default varnish log to false (not log) as this log is mostly for tracing.
Instead, I've enabled by default the ncsa log with the original varnish format.

I've also add log rotation policy which may be configured now from this cookbook.