### PR TITLE
varnish_install resource should only enable service, not restart

### DIFF
--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -57,7 +57,7 @@ class Chef
 
         service 'varnish' do
           supports restart: true, reload: true
-          action %w(enable restart)
+          action %w(enable)
         end
       end
     end


### PR DESCRIPTION
The resource currently restarts the varnish service on every Chef run. 

Recipe version of this only enables: https://github.com/rackspace-cookbooks/varnish/blob/master/recipes/default.rb