### PR TITLE
Make resource_name compatible with older Chef.

### DIFF
--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -2,7 +2,7 @@ class Chef
   class Resource
     # Configure the Varnish service.
     class VarnishDefaultConfig < Chef::Resource::LWRPBase
-      resource_name :varnish_default_config
+      self.resource_name = :varnish_default_config
 
       actions :configure
       default_action :configure

--- a/libraries/varnish_default_vcl.rb
+++ b/libraries/varnish_default_vcl.rb
@@ -2,7 +2,7 @@ class Chef
   class Resource
     # Configure a default Varnish VCL
     class VarnishDefaultVcl < Chef::Resource::LWRPBase
-      resource_name :varnish_default_vcl
+      self.resource_name = :varnish_default_vcl
 
       actions :configure
       default_action :configure

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -2,7 +2,7 @@ class Chef
   class Resource
     # Install Varnish
     class VarnishInstall < Chef::Resource::LWRPBase
-      resource_name :varnish_install
+      self.resource_name = :varnish_install
       actions :install
       default_action :install
 

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -2,7 +2,7 @@ class Chef
   class Resource
     # Configure Varnish logging.
     class VarnishLog < Chef::Resource::LWRPBase
-      resource_name :varnish_log
+      self.resource_name = :varnish_log
       actions :configure
       default_action :configure
 


### PR DESCRIPTION
Switch from passing an argument into resource_name to using the
assignment operator '='. This will make resource_name compatible with
older versions of Chef.