### PR TITLE
Remove apt notification.

### DIFF
--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -39,7 +39,6 @@ class Chef
             components ["varnish-#{new_resource.vendor_version}"]
             key "http://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt"
             deb_src true
-            notifies 'nothing', 'execute[apt-get update]', 'immediately'
           end
         when 'rhel', 'fedora'
           yum_repository 'varnish' do


### PR DESCRIPTION
Fixes #56. The apt resource may not be included, so no need to run a
notification on it.