### PR TITLE
Switch from service restart to service reload.

### DIFF
--- a/libraries/varnish_default_vcl.rb
+++ b/libraries/varnish_default_vcl.rb
@@ -39,7 +39,7 @@ class Chef
             varnish_version: varnish_version
           )
           action :create
-          notifies :restart, 'service[varnish]', :delayed
+          notifies :reload, 'service[varnish]', :delayed
         end
       end
     end


### PR DESCRIPTION
The varnish_default_vcl has been updated to perform a service reload
instead of a service restart. This will prevent the cache from being
cleared when a reload of the vcl file is enough.

Fixes #67 