### PR TITLE
Cause varnish reload to happen after restart.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,15 @@ include_recipe 'varnish::repo' if node['varnish']['use_default_repo']
 
 package 'varnish'
 
+template node['varnish']['default'] do
+  source node['varnish']['conf_source']
+  cookbook node['varnish']['conf_cookbook']
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies 'restart', 'service[varnish]', :delayed
+end
+
 template "#{node['varnish']['dir']}/#{node['varnish']['vcl_conf']}" do
   source node['varnish']['vcl_source']
   cookbook node['varnish']['vcl_cookbook']
@@ -30,15 +39,6 @@ template "#{node['varnish']['dir']}/#{node['varnish']['vcl_conf']}" do
   mode 0644
   notifies :reload, 'service[varnish]', :delayed
   only_if { node['varnish']['vcl_generated'] == true }
-end
-
-template node['varnish']['default'] do
-  source node['varnish']['conf_source']
-  cookbook node['varnish']['conf_cookbook']
-  owner 'root'
-  group 'root'
-  mode 0644
-  notifies 'restart', 'service[varnish]', :delayed
 end
 
 service 'varnish' do


### PR DESCRIPTION
Delayed notifications are queued up in order. In this case, it makes
sense for the reload to happen after the restart. Fixes #69 