### PR TITLE
Fix default storage bug

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,7 +44,7 @@ suites:
     varnish:
       version: '4.0'
       log_daemon: false
-      
+
 - name: distro_libraries
   includes:
     - ubuntu-14.04
@@ -59,3 +59,11 @@ suites:
     - centos-6.6
   run_list:
     - recipe[install_varnish::vendor_install]
+
+- name: libraries_defaults
+  includes:
+    - ubuntu-14.04
+    - centos-7.0
+    - centos-6.6
+  run_list:
+    - recipe[install_varnish::default_settings]

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ end
 
 group :kitchen_vagrant do
   gem 'kitchen-vagrant'
+  gem 'vagrant-wrapper'
 end
 
 group :kitchen_rackspace do

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ files that come with your distro package will be used instead.
 | `group` | string | `'varnish'` |
 | `ttl` | integer | `120` |
 | `storage` | `'malloc'` or `'file'` | `'file'` |
-| `file_storage_path` | string | `nil` |
+| `file_storage_path` | string | `'/var/lib/varnish/%s_storage.bin'` where %s is replaced with the resource name|
 | `file_storage_size` | string | `'1G'` |
 | `malloc_size` | string | `nil` |
 | `path_to_secret` | string | `'/etc/varnish/secret'` |

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -28,7 +28,7 @@ class Chef
       attribute :storage, kind_of: String, default: 'file',
                           equal_to: ['file', 'malloc']
       attribute :file_storage_path, kind_of: String,
-                                    default: nil
+                                    default: '/var/lib/varnish/%s_storage.bin'
       attribute :file_storage_size, kind_of: String, default: '1G'
       attribute :malloc_size, kind_of: String, default: nil
       attribute :parameters, kind_of: Hash,

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,5 +14,6 @@ end
 
 depends 'apt', '~> 2.4'
 depends 'build-essential'
+depends 'chef-sugar'
 depends 'yum', '~> 3.0'
 depends 'yum-epel'

--- a/templates/default/lib_default.erb
+++ b/templates/default/lib_default.erb
@@ -22,9 +22,9 @@ MEMLOCK=<%= @config.max_locked_memory %>
 # Default varnish instance name is the local nodename.  Can be overridden with
 # the -n switch, to have more instances on a single server.
 INSTANCE=<%= @config.instance_name || node['hostname'] %>
-<%- if @config.storage == 'file' %>
-STORAGE=<%= [@config.storage, @config.file_storage_path, @config.file_storage_size].compact.join(",") %>
-<%- else %>
+<%- if @config.storage == 'file' && @config.file_storage_path %>
+STORAGE=<%= [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",") %>
+<%- else @config.storage %>
 STORAGE=<%= [@config.storage, @config.malloc_size].compact.join(",") %>
 <% end %>
 

--- a/templates/default/lib_default_systemd.erb
+++ b/templates/default/lib_default_systemd.erb
@@ -21,8 +21,8 @@ VARNISH_SECRET_FILE=<%= @config.path_to_secret %>
 
 # Backend storage specification, see Storage Types in the varnishd(5)
 # man page for details.
-<%- if @config.storage == 'file' %>
-VARNISH_STORAGE=<%= [@config.storage, @config.file_storage_path, @config.file_storage_size].compact.join(",") %>
+<%- if @config.storage == 'file' && @config.file_storage_path %>
+VARNISH_STORAGE=<%= [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",") %>
 <%- else %>
 VARNISH_STORAGE=<%= [@config.storage, @config.malloc_size].compact.join(",") %>
 <% end %>

--- a/test/fixtures/cookbooks/install_varnish/recipes/default_settings.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/default_settings.rb
@@ -1,0 +1,20 @@
+include_recipe 'chef-sugar'
+include_recipe 'yum-epel' if rhel?
+include_recipe 'apt'
+package 'curl'
+
+varnish_install 'varnish-install' do
+  action :install
+end
+
+varnish_default_config 'varnish-config' do
+  action :configure
+end
+
+varnish_default_vcl 'varnish-vcl' do
+  action :configure
+end
+
+varnish_log 'varnish-log' do
+  action :configure
+end

--- a/test/integration/libraries_defaults/serverspec/default_spec.rb
+++ b/test/integration/libraries_defaults/serverspec/default_spec.rb
@@ -1,0 +1,58 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+%w(varnish varnishlog).each do |varnish_service|
+  describe service(varnish_service) do
+    it 'enabled' do
+      expect(subject).to be_enabled
+    end
+    it 'running' do
+      expect(subject).to be_running
+    end
+  end
+end
+
+def curl_localhost
+  'curl localhost:6081'
+end
+
+describe command(curl_localhost) do
+  it 'exits zero' do
+    expect(subject.exit_status).to eq 0
+  end
+end
+
+['6081', '6082'].each do |port|
+  describe port(port) do
+    it 'listens on the correct port' do
+      expect(subject).to be_listening
+    end
+  end
+end
+
+describe 'Storage bin file exists' do
+  it 'Should find the storage file' do
+    binfile = Dir.glob('/var/lib/varnish/**/*').find { |e| /_storage.bin/ =~ e }
+    expect(binfile).to be_truthy
+  end
+end
+
+describe file('/etc/logrotate.d/varnishlog') do
+  it 'varnishlog exists' do
+    expect(subject).to be_file
+  end
+end
+
+def thread_pool_max
+  'varnishadm -S /etc/varnish/secret -T localhost:6082 param.show thread_pool_max'
+end
+
+describe command(thread_pool_max) do
+  it 'exits zero' do
+    expect(subject.exit_status).to eq 0
+  end
+  it 'returns \'500\' as the content' do
+    expect(subject.stdout).to match(/ 500 /)
+  end
+end

--- a/test/integration/libraries_defaults/serverspec/spec_helper.rb
+++ b/test/integration/libraries_defaults/serverspec/spec_helper.rb
@@ -1,0 +1,10 @@
+# Encoding: utf-8
+require 'serverspec'
+
+set :backend, :exec
+
+RSpec.configure do |c|
+  c.before :all do
+    c.path = '/sbin:/usr/sbin:/bin:/usr/bin'
+  end
+end


### PR DESCRIPTION
- Specify a default file storage location, as one is required with file backend, fixes #72.
- Add a TK test suite and integration tests to verify the default settings on the resources actually produce a working configuration.
- Adjust template for default configuration of varnish so that it won't do the file backend without a path, since that's illegal syntax.