### PR TITLE
Systemd tweaks

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,7 @@ provisioner:
 platforms:
 - name: ubuntu-14.04
 - name: ubuntu-12.04
+- name: debian-8.0
 <% if ENV['CI'] %>
 - name: centos-7
 <% else %>
@@ -32,6 +33,7 @@ suites:
   excludes:
     - centos-7.0
     - centos-7
+    - debian-8.0
   run_list:
   - recipe[varnish]
   attributes:
@@ -48,6 +50,7 @@ suites:
 - name: distro_libraries
   includes:
     - ubuntu-14.04
+    - debian-8.0
     - centos-7.0
     - centos-6.6
   run_list:
@@ -55,6 +58,7 @@ suites:
 - name: vendor_libraries
   includes:
     - ubuntu-14.04
+    - debian-8.0
     - centos-7.0
     - centos-6.6
   run_list:
@@ -63,6 +67,7 @@ suites:
 - name: libraries_defaults
   includes:
     - ubuntu-14.04
+    - debian-8.0
     - centos-7.0
     - centos-6.6
   run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,7 +14,6 @@ provisioner:
 platforms:
 - name: ubuntu-14.04
 - name: ubuntu-12.04
-- name: debian-8.0
 <% if ENV['CI'] %>
 - name: centos-7
 <% else %>
@@ -33,7 +32,6 @@ suites:
   excludes:
     - centos-7.0
     - centos-7
-    - debian-8.0
   run_list:
   - recipe[varnish]
   attributes:
@@ -50,7 +48,6 @@ suites:
 - name: distro_libraries
   includes:
     - ubuntu-14.04
-    - debian-8.0
     - centos-7.0
     - centos-6.6
   run_list:
@@ -58,7 +55,6 @@ suites:
 - name: vendor_libraries
   includes:
     - ubuntu-14.04
-    - debian-8.0
     - centos-7.0
     - centos-6.6
   run_list:
@@ -67,7 +63,6 @@ suites:
 - name: libraries_defaults
   includes:
     - ubuntu-14.04
-    - debian-8.0
     - centos-7.0
     - centos-6.6
   run_list:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,5 +22,18 @@ module VarnishCookbook
         return '/usr/sbin/varnish_reload_vcl'
       end
     end
+
+    def varnish_platform_defaults
+      if node['init_package'] == 'init' && platform_family?('debian')
+        # Ubuntu < 15.04, Debian < 8
+        return { path: '/etc/default/varnish', source: 'lib_default.erb' }
+      elsif node['init_package'] == 'systemd'
+        # Ubuntu >= 15.04, Debian >= 8, CentOS >= 7
+        return { path: '/etc/systemd/system/varnish.service', source: 'lib_default_systemd.erb' }
+      else
+        # CentOS < 7
+        return { path: '/etc/sysconfig/varnish', source: 'lib_default.erb' }
+      end
+    end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -14,5 +14,13 @@ module VarnishCookbook
         Chef::Log.warn "Unable to run varnishd to get version.\nMessage: #{ex.message}"
       end
     end
+
+    def varnish_exec_reload_command
+      if platform_family?('debian')
+        return '/usr/share/varnish/reload-vcl'
+      else
+        return '/usr/sbin/varnish_reload_vcl'
+      end
+    end
   end
 end

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -55,7 +55,7 @@ class Chef
 
       def configure_varnish_service
         template '/etc/default/varnish' do
-          if node['platform_family'] == 'debian'
+          if node['init_package'] == 'init'
             path '/etc/default/varnish'
             source 'lib_default.erb'
           elsif node['init_package'] == 'systemd'

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -61,6 +61,7 @@ class Chef
           elsif node['init_package'] == 'systemd'
             path '/etc/systemd/system/varnish.service'
             source 'lib_default_systemd.erb'
+            notifies :run, 'execute[systemctl-daemon-reload]', :immediately
           else
             path '/etc/sysconfig/varnish'
             source 'lib_default.erb'

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -57,20 +57,8 @@ class Chef
 
       def configure_varnish_service
         template '/etc/default/varnish' do
-          if node['init_package'] == 'init' && node['platform_family'] == 'debian'
-            # Ubuntu < 15.04, Debian < 8
-            path '/etc/default/varnish'
-            source 'lib_default.erb'
-          elsif node['init_package'] == 'systemd'
-            # Ubuntu >= 15.04, Debian >= 8, CentOS >= 7
-            path '/etc/systemd/system/varnish.service'
-            source 'lib_default_systemd.erb'
-            notifies :run, 'execute[systemctl-daemon-reload]', :immediately
-          else
-            # CentOS < 7
-            path '/etc/sysconfig/varnish'
-            source 'lib_default.erb'
-          end
+          path varnish_platform_defaults[:path]
+          source varnish_platform_defaults[:source]
           cookbook 'varnish'
           owner 'root'
           group 'root'
@@ -81,6 +69,7 @@ class Chef
           )
           action :create
           notifies :restart, 'service[varnish]', :delayed
+          notifies :run, 'execute[systemctl-daemon-reload]', :immediately if node['init_package'] == 'systemd'
         end
       end
     end

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -55,14 +55,17 @@ class Chef
 
       def configure_varnish_service
         template '/etc/default/varnish' do
-          if node['init_package'] == 'init'
+          if node['init_package'] == 'init' && node['platform_family'] == 'debian'
+            # Ubuntu < 15.04, Debian < 8
             path '/etc/default/varnish'
             source 'lib_default.erb'
           elsif node['init_package'] == 'systemd'
+            # Ubuntu >= 15.04, Debian >= 8, CentOS >= 7
             path '/etc/systemd/system/varnish.service'
             source 'lib_default_systemd.erb'
             notifies :run, 'execute[systemctl-daemon-reload]', :immediately
           else
+            # CentOS < 7
             path '/etc/sysconfig/varnish'
             source 'lib_default.erb'
           end

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -43,6 +43,8 @@ class Chef
   class Provider
     # Configure the Varnish service.
     class VarnishDefaultConfig < Chef::Provider::LWRPBase
+      include VarnishCookbook::Helpers
+
       def whyrun_supported?
         true
       end
@@ -74,7 +76,8 @@ class Chef
           group 'root'
           mode '0644'
           variables(
-            config: new_resource
+            config: new_resource,
+            exec_reload_command: varnish_exec_reload_command
           )
           action :create
           notifies :restart, 'service[varnish]', :delayed

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -59,7 +59,7 @@ class Chef
             path '/etc/default/varnish'
             source 'lib_default.erb'
           elsif node['init_package'] == 'systemd'
-            path '/etc/varnish/varnish.params'
+            path '/etc/systemd/system/varnish.service'
             source 'lib_default_systemd.erb'
           else
             path '/etc/sysconfig/varnish'

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -28,6 +28,7 @@ class Chef
         end
 
         install_varnish
+        define_systemd_daemon_reload if node['init_package'] == 'systemd'
       end
 
       def add_vendor_repo
@@ -61,6 +62,13 @@ class Chef
         service 'varnish' do
           supports restart: true, reload: true
           action 'nothing'
+        end
+      end
+
+      def define_systemd_daemon_reload
+        execute 'systemctl-daemon-reload' do
+          command '/bin/systemctl --system daemon-reload'
+          action :nothing
         end
       end
     end

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -86,7 +86,7 @@ class Chef
             path "/etc/default/#{new_resource.log_format}"
             source 'lib_varnishlog.erb'
           elsif node['init_package'] == 'systemd'
-            path "/etc/systemd/system/#{new_resource.log_format}.params"
+            path "/etc/systemd/system/#{new_resource.log_format}.service"
             source 'lib_varnishlog_systemd.erb'
           else
             path "/etc/sysconfig/#{new_resource.log_format}"

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -82,7 +82,7 @@ class Chef
 
       def configure_varnish_log
         template "/etc/default/#{new_resource.log_format}" do
-          if node['platform_family'] == 'debian'
+          if node['init_package'] == 'init'
             path "/etc/default/#{new_resource.log_format}"
             source 'lib_varnishlog.erb'
           elsif node['init_package'] == 'systemd'

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -88,6 +88,7 @@ class Chef
           elsif node['init_package'] == 'systemd'
             path "/etc/systemd/system/#{new_resource.log_format}.service"
             source 'lib_varnishlog_systemd.erb'
+            notifies :run, 'execute[systemctl-daemon-reload]', :immediately
           else
             path "/etc/sysconfig/#{new_resource.log_format}"
             source 'lib_varnishlog.erb'

--- a/templates/default/lib_default_systemd.erb
+++ b/templates/default/lib_default_systemd.erb
@@ -1,43 +1,27 @@
-# Varnish environment configuration description. This was derived from
-# the old style sysconfig/defaults settings
+[Unit]
+Description=Varnish HTTP accelerator
+<%- 
+  if @config.storage == 'file' && @config.file_storage_path
+    storage = [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",")
+  else
+    storage = [@config.storage, @config.malloc_size].compact.join(",")
+end %>
+<%- 
+  parameters = ''
+  unless (@config.parameters).nil?
+      @config.parameters.each do |param, value|
+        parameters << "-p #{param.to_s}=#{value} "
+    end
+  end
+%>
 
-# Set this to 1 to make systemd reload try to switch vcl without restart.
-RELOAD_VCL=1
-# Main configuration file. You probably want to change it.
-VARNISH_VCL_CONF=<%= @config.path_to_vcl %>
+[Service]
+Type=forking
+LimitNOFILE=131072
+LimitMEMLOCK=82000
+ExecStartPre=/usr/sbin/varnishd -C -f <%= @config.path_to_vcl %>
+ExecStart=/usr/sbin/varnishd -a <%= @config.listen_address %>:<%= @config.listen_port %> -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> -f <%= @config.path_to_vcl %> -S <%= @config.path_to_secret %> -s <%= storage %> <%= parameters %> 
+ExecReload=/usr/share/varnish/reload-vcl
 
-# Default address and port to bind to. Blank address means all IPv4
-# and IPv6 interfaces, otherwise specify a host name, an IPv4 dotted
-# quad, or an IPv6 address in brackets.
-VARNISH_LISTEN_ADDRESS=<%= @config.listen_address %>
-VARNISH_LISTEN_PORT=<%= @config.listen_port %>
-
-# Admin interface listen address and port
-VARNISH_ADMIN_LISTEN_ADDRESS=<%= @config.admin_listen_address %>
-VARNISH_ADMIN_LISTEN_PORT=<%= @config.admin_listen_port %>
-
-# Shared secret file for admin interface
-VARNISH_SECRET_FILE=<%= @config.path_to_secret %>
-
-# Backend storage specification, see Storage Types in the varnishd(5)
-# man page for details.
-<%- if @config.storage == 'file' && @config.file_storage_path %>
-VARNISH_STORAGE=<%= [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",") %>
-<%- else %>
-VARNISH_STORAGE=<%= [@config.storage, @config.malloc_size].compact.join(",") %>
-<% end %>
-
-# Default TTL used when the backend does not specify one
-VARNISH_TTL=<%= @config.ttl %>
-
-# User and group for the varnishd worker processes
-VARNISH_USER=<%= @config.user %>
-VARNISH_GROUP=<%= @config.group %>
-
-# Other options, see the man page varnishd(1)
-#DAEMON_OPTS="-p thread_pool_min=5 -p thread_pool_max=500 -p thread_pool_timeout=300"
-<%- unless (@config.parameters).nil? %>
-DAEMON_OPTS="<%- @config.parameters.each do |param, value| %> \
-             -p <%= param.to_s + "=" + value %> \
-                <%- end %>
-<%- end %>
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/lib_default_systemd.erb
+++ b/templates/default/lib_default_systemd.erb
@@ -17,8 +17,8 @@ Description=Varnish HTTP accelerator
 
 [Service]
 Type=forking
-LimitNOFILE=131072
-LimitMEMLOCK=82000
+LimitNOFILE=<%= @config.max_open_files %>
+LimitMEMLOCK=<%= @config.max_locked_memory %>
 ExecStartPre=/usr/sbin/varnishd -C -f <%= @config.path_to_vcl %>
 ExecStart=/usr/sbin/varnishd -a <%= @config.listen_address %>:<%= @config.listen_port %> -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> -f <%= @config.path_to_vcl %> -S <%= @config.path_to_secret %> -s <%= storage %> <%= parameters %>
 ExecReload=/usr/share/varnish/reload-vcl

--- a/templates/default/lib_default_systemd.erb
+++ b/templates/default/lib_default_systemd.erb
@@ -1,12 +1,10 @@
-[Unit]
-Description=Varnish HTTP accelerator
-<%- 
+<%-
   if @config.storage == 'file' && @config.file_storage_path
     storage = [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",")
   else
     storage = [@config.storage, @config.malloc_size].compact.join(",")
 end %>
-<%- 
+<%-
   parameters = ''
   unless (@config.parameters).nil?
       @config.parameters.each do |param, value|
@@ -14,13 +12,15 @@ end %>
     end
   end
 %>
+[Unit]
+Description=Varnish HTTP accelerator
 
 [Service]
 Type=forking
 LimitNOFILE=131072
 LimitMEMLOCK=82000
 ExecStartPre=/usr/sbin/varnishd -C -f <%= @config.path_to_vcl %>
-ExecStart=/usr/sbin/varnishd -a <%= @config.listen_address %>:<%= @config.listen_port %> -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> -f <%= @config.path_to_vcl %> -S <%= @config.path_to_secret %> -s <%= storage %> <%= parameters %> 
+ExecStart=/usr/sbin/varnishd -a <%= @config.listen_address %>:<%= @config.listen_port %> -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> -f <%= @config.path_to_vcl %> -S <%= @config.path_to_secret %> -s <%= storage %> <%= parameters %>
 ExecReload=/usr/share/varnish/reload-vcl
 
 [Install]

--- a/templates/default/lib_default_systemd.erb
+++ b/templates/default/lib_default_systemd.erb
@@ -3,8 +3,8 @@
     storage = [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",")
   else
     storage = [@config.storage, @config.malloc_size].compact.join(",")
-end %>
-<%-
+  end
+
   parameters = ''
   unless (@config.parameters).nil?
       @config.parameters.each do |param, value|
@@ -21,7 +21,7 @@ LimitNOFILE=<%= @config.max_open_files %>
 LimitMEMLOCK=<%= @config.max_locked_memory %>
 ExecStartPre=/usr/sbin/varnishd -C -f <%= @config.path_to_vcl %>
 ExecStart=/usr/sbin/varnishd -a <%= @config.listen_address %>:<%= @config.listen_port %> -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> -f <%= @config.path_to_vcl %> -S <%= @config.path_to_secret %> -s <%= storage %> <%= parameters %>
-ExecReload=/usr/share/varnish/reload-vcl
+ExecReload=<%= @exec_reload_command %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With Debian 8 using systemd, the cookbook needs some slight tweaking to handle it. Compatibility with other platforms in the .kitchen.yml is preserved.

I've replaced checking against `node['platform_family']` with `node['init_package']`, overriding the varnish unit files in /etc/systemd/system/varnish*.service and added systemd-daemon-reload to ensure any changes made by the cookbook are picked up by systemd before Chef attempts to restart the service(s).