### PR TITLE
[BUG] Fix for service resource failures

### DIFF
--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -26,25 +26,29 @@ class Chef
   module ProviderExtensions
     def restart_service
       tries ||= 5
-      begin
-        if @new_resource.service_name =~ /varnish(log|ncsa)/
+      if @new_resource.service_name =~ /varnish(log|ncsa)/
+        begin
           sleep 5
+          super
+        rescue
+          retry unless (tries -= 1).zero?
         end
+      else
         super
-      rescue
-        retry unless (tries -= 1).zero?
       end
     end
 
     def start_service
       tries ||= 5
-      begin
-        if @new_resource.service_name =~ /varnish(log|ncsa)/
+      if @new_resource.service_name =~ /varnish(log|ncsa)/
+        begin
           sleep 5
+          super
+        rescue
+          retry unless (tries -= 1).zero?
         end
+      else
         super
-      rescue
-        retry unless (tries -= 1).zero?
       end
     end
   end


### PR DESCRIPTION
I've noticed what I assume is a bug when using the Varnish cookbook. 

Services that fail to start (e.g. an init script fails) would not correctly terminate a Chef run with an error. Instead 5 attempts will be made to start the service then the service will be reported as started even if it fails.
I performed debugging on the service resource and the correct code logic is being executed to trigger an exception. The problem is ProviderExtensions module being prepended to the service class which alters the behaviour.

This pull request alters the behaviour of the ProviderExtension to only affect the varnish log services.