### PR TITLE
Fix build issues, runtime order issues

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 driver_config:
-  require_chef_omnibus: true
+  require_chef_omnibus: 12.5.1 # 11.18.12
 
 provisioner:
   name: chef_zero
@@ -22,7 +22,7 @@ platforms:
   run_list:
     - recipe[disable_ipv6::disable_ipv6]
     - recipe[yum-epel]
-- name: centos-6.6
+- name: centos-6.7
   run_list:
     - recipe[disable_ipv6::disable_ipv6]
     - recipe[yum-epel]
@@ -49,14 +49,15 @@ suites:
   includes:
     - ubuntu-14.04
     - centos-7.0
-    - centos-6.6
+    - centos-6.7
   run_list:
     - recipe[install_varnish::distro_install]
+    
 - name: vendor_libraries
   includes:
     - ubuntu-14.04
     - centos-7.0
-    - centos-6.6
+    - centos-6.7
   run_list:
     - recipe[install_varnish::vendor_install]
 
@@ -64,6 +65,6 @@ suites:
   includes:
     - ubuntu-14.04
     - centos-7.0
-    - centos-6.6
+    - centos-6.7
   run_list:
     - recipe[install_varnish::default_settings]

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :lint do
 end
 
 group :unit do
-  gem 'berkshelf', '~> 3'
+  gem 'berkshelf', '~> 4'
   gem 'chefspec', '~> 4'
   gem 'chef-sugar'
 end

--- a/libraries/varnish_default_vcl.rb
+++ b/libraries/varnish_default_vcl.rb
@@ -28,7 +28,12 @@ class Chef
       end
 
       def configure_varnish_vcl
-        template '/etc/varnish/default.vcl' do
+        service 'varnish' do
+          supports restart: true, reload: true
+          action :nothing
+        end
+
+        tmp = template '/etc/varnish/default.vcl' do
           source 'lib_default.vcl.erb'
           cookbook 'varnish'
           owner 'root'
@@ -38,9 +43,12 @@ class Chef
             config: new_resource,
             varnish_version: varnish_version
           )
-          action :create
+          action :nothing
           notifies :reload, 'service[varnish]', :delayed
         end
+        tmp.run_action(:create)
+
+        new_resource.updated_by_last_action(true) if tmp.updated_by_last_action?
       end
     end
   end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -34,6 +34,6 @@ when 'rhel', 'fedora'
     url "http://repo.varnish-cache.org/redhat/varnish-#{node['varnish']['version']}/el#{node['platform_version'].to_i}/"
     gpgcheck false
     gpgkey 'http://repo.varnish-cache.org/debian/GPG-key.txt'
-    action 'create'
+    action :create
   end
 end

--- a/test/fixtures/cookbooks/install_varnish/recipes/distro_install.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/distro_install.rb
@@ -12,7 +12,7 @@ directory 'logrotate' do
   user 'root'
   group 'root'
   mode '0755'
-  action 'create'
+  action :create
 end
 
 varnish_default_config 'default' do

--- a/test/fixtures/cookbooks/install_varnish/recipes/vendor_install.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/vendor_install.rb
@@ -13,7 +13,7 @@ directory 'logrotate' do
   user 'root'
   group 'root'
   mode '0755'
-  action 'create'
+  action :create
 end
 
 varnish_default_config 'default' do

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -24,7 +24,7 @@ def stub_resources
   allow(Mixlib::ShellOut).to receive(:new).with('varnishd -V 2>&1').and_return(shellout)
   allow(shellout).to receive(:run_command).and_return(shellout)
   allow(shellout).to receive(:error!).and_return(true)
-  allow(shellout).to receive(:stdout).and_return(true)
+  allow(shellout).to receive(:stdout).and_return('varnish-4.0')
   allow(shellout).to receive(:environment).and_return('/root')
   allow(shellout.environment).to receive(:[]=).and_return('/root')
   allow(shellout.stdout).to receive(:match).and_return(true)


### PR DESCRIPTION
- Use latest chef for testing
- Switch to centos 6.7 since 6.6 is no longer available
- Raise exceptions in a way where we can actually see the error
- Use chef resources during provider converge phase, instead of just declaring them to run later
- Force varnish restart when configs change, or tests fail