### PR TITLE
Move define_systemd_daemon_reload to helpers

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,5 +44,12 @@ module VarnishCookbook
         return { path: '/etc/sysconfig/varnish', source: 'lib_default.erb' }
       end
     end
+
+    def define_systemd_daemon_reload
+      execute 'systemctl-daemon-reload' do
+        command '/bin/systemctl --system daemon-reload'
+        action :nothing
+      end
+    end
   end
 end

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -52,6 +52,7 @@ class Chef
       use_inline_resources
 
       def action_configure
+        define_systemd_daemon_reload if node['init_package'] == 'systemd'
         configure_varnish_service
       end
 

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -28,7 +28,6 @@ class Chef
         end
 
         install_varnish
-        define_systemd_daemon_reload if node['init_package'] == 'systemd'
       end
 
       def add_vendor_repo
@@ -74,13 +73,6 @@ class Chef
         end
 
         new_resource.updated_by_last_action(true) if svc.updated_by_last_action? || pack.updated_by_last_action?
-      end
-
-      def define_systemd_daemon_reload
-        execute 'systemctl-daemon-reload' do
-          command '/bin/systemctl --system daemon-reload'
-          action :nothing
-        end
       end
     end
   end

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -30,6 +30,7 @@ class Chef
       end
 
       def action_configure
+        define_systemd_daemon_reload if node['init_package'] == 'systemd'
         configure_varnish_log
       end
 


### PR DESCRIPTION
I've moved define_systemd_daemon_reload to helpers, as it's used in both varnish_default_config and varnish_log, and ensure it's defined before the notification can be called. This PR fixes up a mistake in 9349f8d, so apologies for that.

(Removed from varnish_install as it's not used there and shouldn't be defined there either.)