### PR TITLE
Fix Chef::Exceptions::ChecksumMismatch error and unexpected service restarts

### DIFF
--- a/templates/default/default.erb
+++ b/templates/default/default.erb
@@ -31,7 +31,7 @@ DAEMON_OPTS="-a <%= node['varnish']['listen_address'] %>:<%= node['varnish']['li
              <%- end %>
               -s <%= node['varnish']['storage'] %>,<%= (node['varnish']['storage']=='file')?"#{node['varnish']['storage_file']},":'' %><%= node['varnish']['storage_size'] %> \
               <%- if !(node['varnish']['parameters']).nil? %>
-                <%- node['varnish']['parameters'].each do |param, value| %>
+                <%- node['varnish']['parameters'].sort.each do |param, value| %>
                   -p <%= param + "=" + value %> \
                 <%- end %>
               <%- end %>

--- a/templates/default/lib_default.erb
+++ b/templates/default/lib_default.erb
@@ -40,7 +40,7 @@ DAEMON_OPTS="-a <%= @config.listen_address %>:<%= @config.listen_port %> \
              <%- end %>
               -s $STORAGE \
               <%- unless (@config.parameters).nil? %>
-                <%- @config.parameters.each do |param, value| %>
+                <%- @config.parameters.sort.each do |param, value| %>
                   -p <%= param.to_s + "=" + value %> \
                 <%- end %>
               <%- end %>


### PR DESCRIPTION
if yu use something like

```ruby
varnish_default_config 'default' do
  # ...
  parameters(thread_pools: '2',
             thread_pool_min: '5',
             thread_pool_max: '500',
             thread_pool_timeout: '300')
end
```

The template iterates the hash and produces a different configuration file every time.
This has two issues:

1.  First and most important, it will cause the restart of varnish when isn't really needed.
2.  Chef seems to execute the templates twice and verify the checksum, causing the ChecksumMismatch mentioned.