### PR TITLE
Fix systemctl-daemon-reload

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,7 +45,7 @@ module VarnishCookbook
       end
     end
 
-    def define_systemd_daemon_reload
+    def systemd_daemon_reload
       execute 'systemctl-daemon-reload' do
         command '/bin/systemctl --system daemon-reload'
         action :nothing

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -52,7 +52,6 @@ class Chef
       use_inline_resources
 
       def action_configure
-        define_systemd_daemon_reload if node['init_package'] == 'systemd'
         configure_varnish_service
       end
 
@@ -74,12 +73,11 @@ class Chef
             exec_reload_command: varnish_exec_reload_command
           )
           action :nothing
-          notifies :restart, 'service[varnish]', :delayed
-          notifies :run, 'execute[systemctl-daemon-reload]', :immediately if node['init_package'] == 'systemd'
         end
         tmp.run_action(:create)
 
         if tmp.updated_by_last_action?
+          systemd_daemon_reload.run_action(:run) if node['init_package'] == 'systemd'
           svc.run_action(:restart)
         end
 

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -30,7 +30,7 @@ class Chef
       end
 
       def action_configure
-        define_systemd_daemon_reload if node['init_package'] == 'systemd'
+        systemd_daemon_reload.run_action(:run) if node['init_package'] == 'systemd'
         configure_varnish_log
       end
 


### PR DESCRIPTION
Hi! Just noticed that systemctl-daemon-reload never runs due to updated_by_last_action & run_action changes introduced in 41b7974. We need to use run_action - same as the service - so systemd picks up the service unit changes before we restart the service. Thanks!
