### PR TITLE
Loosen version constraints of yum and apt cookbooks

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,8 +12,8 @@ recipe 'varnish::repo', 'Adds the official varnish project repository'
   supports os
 end
 
-depends 'apt', '~> 2.4'
+depends 'apt', '>= 2.4', '< 4.1'
 depends 'build-essential'
 depends 'chef-sugar'
-depends 'yum', '~> 3.0'
+depends 'yum', '>= 3.0', '< 4.1'
 depends 'yum-epel'


### PR DESCRIPTION
Version constraints of yum and apt cookbooks is too tight, and old.
Latest versions of these cookbooks (apt 4.0.2, yum 4.0.0) seems to work fine with this cookbook.
