### PR TITLE
Don't fetch the repository key over insecure HTTP

### DIFF
--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -24,7 +24,7 @@ when 'debian'
     uri "http://repo.varnish-cache.org/#{node['platform']}"
     distribution node['lsb']['codename']
     components ["varnish-#{node['varnish']['version']}"]
-    key "http://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt"
+    key "https://repo.varnish-cache.org/#{node['platform']}/GPG-key.txt"
     deb_src true
     notifies 'nothing', 'execute[apt-get update]', 'immediately'
   end
@@ -33,7 +33,7 @@ when 'rhel', 'fedora'
     description "Varnish #{node['varnish']['version']} repo (#{node['platform_version']} - $basearch)"
     url "http://repo.varnish-cache.org/redhat/varnish-#{node['varnish']['version']}/el#{node['platform_version'].to_i}/"
     gpgcheck false
-    gpgkey 'http://repo.varnish-cache.org/debian/GPG-key.txt'
+    gpgkey 'https://repo.varnish-cache.org/debian/GPG-key.txt'
     action :create
   end
 end


### PR DESCRIPTION
Even this is less than ideal. My usual preferred approach is to specify the key fingerprint in the cookbook, and grab it from a keyserver. Sadly, that usually proves a little more unreliable than an http request like this. (The apt cookbook doesn't retry key downloads)
