### PR TITLE
Support for Varnish 4.1

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,13 @@ suites:
     varnish:
       version: '4.0'
       log_daemon: false
+- name: varnish41
+  run_list:
+  - recipe[varnish]
+  attributes:
+    varnish:
+      version: '4.1'
+      log_daemon: false
 
 - name: distro_libraries
   includes:
@@ -60,6 +67,14 @@ suites:
     - centos-6.7
   run_list:
     - recipe[install_varnish::vendor_install]
+
+- name: vendor_41_libraries
+  includes:
+    - ubuntu-14.04
+    - centos-7.0
+    - centos-6.7
+  run_list:
+    - recipe[install_varnish::vendor_41_install]
 
 - name: libraries_defaults
   includes:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Tested on:
 * Centos 6.5
 * Centos 7.0
 
+With varnish versions:
+
+* 3
+* 4
+* 4.1
+
 Attributes
 ----------
 * `node['varnish']['dir']` - location of the varnish configuration
@@ -44,7 +50,8 @@ Attributes
 * `node['varnish']['admin_listen_address']` - Telnet admin interface listen address (127.0.0.1)
 * `node['varnish']['admin_listen_port']` - Telnet admin interface listen port (6082)
 * `node['varnish']['user']` - Specifies the name of an unprivileged user to which the child process should switch before it starts  accepting  connections (varnish)
-* `node['varnish']['group']` - Specifies  the name of an unprivileged group to which the child process should switch before it starts accepting connections (varnish)
+* `node['varnish']['group']` - Only used on varnish versions before 4.1. Specifies  the name of an unprivileged group to which the child process should switch before it starts accepting connections (varnish)
+* `node['varnish']['ccgroup']` - Only used on varnish version 4.1. A group to add to varnish requiring access to a c-compiler, refer to the varnishd man page for more info. (not set by default)
 * `node['varnish']['ttl']` - Specifies  a hard minimum time to live for cached documents. (120)
 * `node['varnish']['storage']` - The storage type used ('file')
 * `node['varnish']['storage_file']` -  Specifies either the path to the backing file or the path to a directory in which varnishd will create the backing file. Only used if using file storage. ('/var/lib/varnish/$INSTANCE/varnish_storage.bin')
@@ -129,7 +136,8 @@ files that come with your distro package will be used instead.
 | `admin_listen_address` | string | `'127.0.0.1'` |
 | `admin_plisten_port` | integer | `6082` |
 | `user` | string | `'varnish'` |
-| `group` | string | `'varnish'` |
+| `group` | string | `'varnish'` | Only used on varnish versions before 4.1
+| `ccgroup` | string | `nil` | Only used on varnish 4.1
 | `ttl` | integer | `120` |
 | `storage` | `'malloc'` or `'file'` | `'file'` |
 | `file_storage_path` | string | `'/var/lib/varnish/%s_storage.bin'` where %s is replaced with the resource name|

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,7 @@ default['varnish']['admin_listen_address'] = '127.0.0.1'
 default['varnish']['admin_listen_port'] = '6082'
 default['varnish']['user'] = 'varnish'
 default['varnish']['group'] = 'varnish'
+default['varnish']['ccgroup'] = nil
 default['varnish']['ttl'] = '120'
 default['varnish']['parameters']['thread_pools'] = '4'
 default['varnish']['parameters']['thread_pool_min'] = '5'

--- a/files/default/reload-vcl
+++ b/files/default/reload-vcl
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+# reload-varnish: Script to reload varnishd from VCL defined in
+# /etc/default/varnish.
+#
+# Stig Sandbeck Mathisen <ssm@debian.org>
+
+# Settings
+defaults=/etc/default/varnish
+secret=/etc/varnish/secret
+
+# Paths
+varnishadm=/usr/bin/varnishadm
+date=/bin/date
+tempfile=/bin/tempfile
+
+# Messages
+# msg_no_varnishadm: varnishadm
+msg_no_varnishadm="Error: Cannot execute %s\n"
+msg_no_management="Management port disabled. \$DAEMON_OPTS must contain '-T hostname:port'\n"
+# msg_defaults_not_readable: defaults
+msg_defaults_not_readable="Error: %s is not readable\n"
+# msg_defaults_not_there: defaults
+msg_defaults_not_there="Error: %s does not exist\n"
+msg_no_vcl="Error: No VCL file used, nothing to reload\n"
+msg_usage="Usage: $0 [-h][-c][-q]\n\t-h\tdisplay help\n\t-q\tquiet\n\t-c\tcompile only, do not reload\n"
+# msg_compile_only: varnishadm, mgmt_interface, vcl_label
+msg_compile_only="To activate, run:\n\t%s -T %s \\\\\n\tvcl.use %s\n"
+# msg_compile_failed: vcl_label, vcl_file
+msg_compile_failed="Error: vcl.load %s %s failed"
+# msg_use_ok: vcl_label
+msg_use_ok="VCL reloaded, active label is %s\n"
+# msg_use_failed: vcl_label
+msg_use_failed="Error: vcl.use %s failed\n"
+# msg_secret_not_readable: secret
+msg_secret_not_readable="Error: Secret file %s is not readable\n"
+# msg_secret_not_there: secret
+msg_secret_not_there="Error: Secret file %s does not exist\n"
+
+# Generate a label, prefixed with the caller's username, from the
+# kernel random uuid generator, fallback to timestamp
+if [ -f /proc/sys/kernel/random/uuid ]
+then
+    uuid=$(cat /proc/sys/kernel/random/uuid)
+    vcl_label="${LOGNAME}${LOGNAME:+:}${uuid}"
+else
+    vcl_label="$($date +${LOGNAME}${LOGNAME:+:}%s.%N)"
+fi
+
+# Load defaults file
+if [ -f "$defaults" ]
+then
+    if [ -r "$defaults" ]
+    then
+	. "$defaults"
+    else
+	printf >&2 "$msg_defaults_not_readable" $defaults
+	exit 1
+    fi
+else
+    printf >&2 "$msg_defaults_not_there" $defaults
+    exit 1
+fi
+
+# parse command line arguments
+while getopts hcq flag
+do
+    case $flag in
+	h)
+	    printf >&2 "$msg_usage"
+	    exit 0
+	    ;;
+	c)
+	    compile_only=1
+	    ;;
+	q)
+	    quiet=1
+	    ;;
+	*)
+	    printf >&2 "$msg_usage\n"
+	    exit 1
+	    ;;
+    esac
+done
+
+# Parse $DAEMON_OPTS (options must be kept in sync with varnishd).
+# Extract the -f and the -T option, and (try to) ensure that the
+# management interface is on the form hostname:address.
+OPTIND=1
+while getopts j:a:b:CdFf:g:h:i:l:M:n:P:p:S:s:T:t:u:Vw: flag $DAEMON_OPTS
+do
+    case $flag in
+		f)
+			if [ -f "$OPTARG" ]; then
+				vcl_file="$OPTARG"
+			fi
+			;;
+		T)
+			if [ -n "$OPTARG" -a "$OPTARG" != "${OPTARG%%:*}" ]
+			then
+				mgmt_interface="$OPTARG"
+			fi
+			;;
+		S)
+			secret="$OPTARG"
+			;;
+    esac
+done
+
+
+# Sanity checks
+if [ ! -x "$varnishadm" ]
+then
+    printf >&2 "$msg_no_varnishadm" $varnishadm
+    exit 1
+fi
+
+if [ -z "$mgmt_interface" ]
+then
+    printf >&2 "$msg_no_management"
+    exit 1
+fi
+
+if [ -z "$vcl_file" ]
+then
+    printf >&2 "$msg_no_vcl"
+    exit 1
+fi
+
+# Check secret file
+if [ -f "$secret" ]
+	then
+	if [ ! -r "$secret" ]
+	then
+		printf >&2 "$msg_secret_not_readable" $secret
+		exit 1
+	fi
+else
+	printf >&2 "$msg_secret_not_there" $secret
+	exit 1
+fi
+
+logfile=$($tempfile -n /tmp/$vcl_label)
+
+# Compile and maybe reload
+if $varnishadm -T $mgmt_interface -S ${secret} vcl.load $vcl_label $vcl_file
+then
+    if [ -n "$compile_only" ]
+    then
+	printf "$msg_compile_only" $varnishadm $mgmt_interface $vcl_label
+    else
+	if $varnishadm -T $mgmt_interface -S ${secret} vcl.use $vcl_label
+	then
+	    printf "$msg_use_ok" $vcl_label
+	else
+	    printf "$msg_use_failed" $vcl_label
+	    exitstatus=1
+	fi
+    fi
+else
+    printf "$msg_compile_failed" $vcl_label $vcl_file
+    exitstatus=1
+fi > $logfile
+
+# Blather
+if [ -z "${quiet}" -o -n "$exitstatus" ]
+then
+    grep -v '^$' >&2 $logfile
+fi
+
+# Cleanup
+rm -f $logfile
+exit $exitstatus

--- a/files/default/reload-vcl
+++ b/files/default/reload-vcl
@@ -3,6 +3,9 @@
 # reload-varnish: Script to reload varnishd from VCL defined in
 # /etc/default/varnish.
 #
+# This is free software, distributed under the standard 2 clause BSD license,
+# see the copyright file in the Varnish documentation directory
+#
 # Stig Sandbeck Mathisen <ssm@debian.org>
 
 # Settings

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,11 +13,12 @@ module VarnishCookbook
         raise "Output of #{cmd_str} was nil; can't determine varnish version" unless cmd_stdout
         Chef::Log.debug "#{cmd_str} ran and detected varnish version: #{cmd_stdout}"
 
-        matches = cmd_stdout.match(/varnish-([0-9])\./)
-        version_found = matches && matches.captures && matches.captures[0]
+        matches = cmd_stdout.match(/varnish-([0-9])\.([0-9])/)
+        version_found = matches && matches.captures
         raise "Cannot parse varnish version from #{cmd_stdout}" unless version_found
 
-        return version_found
+
+        return matches.captures
       rescue => ex
         Chef::Log.warn 'Unable to run varnishd to get version.'
         raise ex

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -24,6 +24,7 @@ class Chef
       attribute :admin_listen_port, kind_of: Fixnum, default: 6082
       attribute :user, kind_of: String, default: 'varnish'
       attribute :group, kind_of: String, default: 'varnish'
+      attribute :ccgroup, kind_of: String
       attribute :ttl, kind_of: Fixnum, default: 120
       attribute :storage, kind_of: String, default: 'file',
                           equal_to: ['file', 'malloc']
@@ -71,6 +72,7 @@ class Chef
           mode '0644'
           variables(
             config: new_resource,
+            varnish_version: varnish_version.join('.').to_i,
             exec_reload_command: varnish_exec_reload_command
           )
           action :nothing

--- a/libraries/varnish_default_config.rb
+++ b/libraries/varnish_default_config.rb
@@ -72,7 +72,7 @@ class Chef
           mode '0644'
           variables(
             config: new_resource,
-            varnish_version: varnish_version.join('.').to_i,
+            varnish_version: varnish_version.join('.').to_f,
             exec_reload_command: varnish_exec_reload_command
           )
           action :nothing

--- a/libraries/varnish_default_vcl.rb
+++ b/libraries/varnish_default_vcl.rb
@@ -44,7 +44,7 @@ class Chef
           mode '0644'
           variables(
             config: new_resource,
-            varnish_version: varnish_version,
+            varnish_version: varnish_version.join('.').to_i,
             parameters: new_resource.vcl_parameters
           )
           action :nothing

--- a/libraries/varnish_default_vcl.rb
+++ b/libraries/varnish_default_vcl.rb
@@ -44,7 +44,7 @@ class Chef
           mode '0644'
           variables(
             config: new_resource,
-            varnish_version: varnish_version.join('.').to_i,
+            varnish_version: varnish_version.join('.').to_f,
             parameters: new_resource.vcl_parameters
           )
           action :nothing

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -16,6 +16,8 @@ class Chef
   class Provider
     # Install Varnish
     class VarnishInstall < Chef::Provider::LWRPBase
+      include VarnishCookbook::Helpers
+
       use_inline_resources
 
       def whyrun_supported?
@@ -79,6 +81,12 @@ class Chef
           gid 113
           members 'varnishlog'
           only_if { node['platform'] == 'ubuntu' }
+        end
+
+        # The reload-vcl script doesn't support the -j option and breaks reload on ubuntu, need to open a ticket on this.
+        cookbook_file '/usr/share/varnish/reload-vcl' do
+          source 'varnish-vcl'
+          only_if { platform_family?('debian') && varnish_version.join('.').to_f >= 4.1 }
         end
 
         new_resource.updated_by_last_action(true) if svc.updated_by_last_action? || pack.updated_by_last_action?

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -61,6 +61,7 @@ class Chef
         reload_vcl = cookbook_file '/usr/share/varnish/reload-vcl' do
           action :nothing
           source 'reload-vcl'
+          cookbook 'varnish'
           only_if { platform_family?('debian') && varnish_version.join('.').to_f >= 4.1 }
         end
 

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -87,7 +87,6 @@ class Chef
         # enabled on debian systems
         group 'varnishlog' do
           system true
-          gid 113
           members 'varnishlog'
           only_if { node['platform_family'] == 'debian' }
         end.run_action(:create)

--- a/libraries/varnish_install.rb
+++ b/libraries/varnish_install.rb
@@ -72,6 +72,15 @@ class Chef
           svc.run_action(:restart)
         end
 
+        # The latest vendor package does not create the varnishlog group but expects it to exist if varnishlog is
+        # enabled on ubuntu so let's make sure it exists here.
+        group 'varnishlog' do
+          system true
+          gid 113
+          members 'varnishlog'
+          only_if { node['platform'] == 'ubuntu' }
+        end
+
         new_resource.updated_by_last_action(true) if svc.updated_by_last_action? || pack.updated_by_last_action?
       end
     end

--- a/libraries/varnish_log.rb
+++ b/libraries/varnish_log.rb
@@ -53,7 +53,7 @@ class Chef
           mode '0644'
           variables(
             config: new_resource,
-            varnish_version: varnish_version
+            varnish_major_version: varnish_version[0]
           )
           action :create
           notifies :restart, "service[#{new_resource.log_format}]", :delayed

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Rackspace'
 maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs and configures varnish'
-version '2.4.0'
+version '2.5.0'
 
 recipe 'varnish', 'Installs and configures varnish'
 recipe 'varnish::repo', 'Adds the official varnish project repository'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,6 +41,13 @@ template "#{node['varnish']['dir']}/#{node['varnish']['vcl_conf']}" do
   only_if { node['varnish']['vcl_generated'] == true }
 end
 
+# The reload-vcl script doesn't support the -j option and breaks reload on ubuntu, need to open a ticket on this.
+cookbook_file '/usr/share/varnish/reload-vcl' do
+  extend VarnishCookbook::Helpers
+  source 'reload-vcl'
+  only_if { platform_family?('debian') && varnish_version.join('.').to_f >= 4.1 }
+end
+
 service 'varnish' do
   supports restart: true, reload: true
   action %w(enable)

--- a/templates/default/default.erb
+++ b/templates/default/default.erb
@@ -21,10 +21,15 @@ INSTANCE=<%= node['varnish']['instance'] %>
 
 # Pass the Daemon options
 
-DAEMON_OPTS="-a <%= node['varnish']['listen_address'] %>:<%= node['varnish']['listen_port'] %> \
+DAEMON_OPTS=" \
+              <%- if node['varnish']['version'] =~ /^4.1/ %>
+                -j unix,user=<%= node['varnish']['user'] %><%= ",ccgroup=#{node['varnish']['ccgroup']}" if node['varnish']['ccgroup'] %> \
+              <%- else %>
+                -u <%= node['varnish']['user'] %> -g <%= node['varnish']['group'] %> \
+              <%- end %>
+              -a <%= node['varnish']['listen_address'] %>:<%= node['varnish']['listen_port'] %> \
               -f <%= node['varnish']['dir'] %>/<%= node['varnish']['vcl_conf'] %> \
               -T <%= node['varnish']['admin_listen_address'] %>:<%= node['varnish']['admin_listen_port'] %> \
-              -u <%= node['varnish']['user'] %> -g <%= node['varnish']['group'] %> \
               -t <%= node['varnish']['ttl'] %> \
              <%- if node['platform_family'] == 'debian' %>
               -n $INSTANCE \

--- a/templates/default/default.vcl.erb
+++ b/templates/default/default.vcl.erb
@@ -1,4 +1,4 @@
-<%- if node['varnish']['version'] == '4.0' %>
+<%- if node['varnish']['version'] =~ /^4/ %>
 vcl 4.0;
 <%- end %>
 backend default {

--- a/templates/default/lib_default.erb
+++ b/templates/default/lib_default.erb
@@ -25,7 +25,7 @@ INSTANCE=<%= @config.instance_name || node['hostname'] %>
 <%- if @config.storage == 'file' && @config.file_storage_path %>
 STORAGE=<%= [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",") %>
 <%- else @config.storage %>
-STORAGE=<%= [@config.storage, @malloc_size].compact.join(",") %>
+STORAGE=<%= [@config.storage, @config.malloc_size].compact.join(",") %>
 <% end %>
 
 # Pass the Daemon options

--- a/templates/default/lib_default.erb
+++ b/templates/default/lib_default.erb
@@ -25,15 +25,20 @@ INSTANCE=<%= @config.instance_name || node['hostname'] %>
 <%- if @config.storage == 'file' && @config.file_storage_path %>
 STORAGE=<%= [@config.storage, (@config.file_storage_path % @config.name), @config.file_storage_size].compact.join(",") %>
 <%- else @config.storage %>
-STORAGE=<%= [@config.storage, @config.malloc_size].compact.join(",") %>
+STORAGE=<%= [@config.storage, @malloc_size].compact.join(",") %>
 <% end %>
 
 # Pass the Daemon options
 
-DAEMON_OPTS="-a <%= @config.listen_address %>:<%= @config.listen_port %> \
+DAEMON_OPTS=" \
+              <%- if @varnish_version >= 4.1 %>
+                  -j unix,user=<%= @config.user %><%= ",ccgroup=#{@config.ccgroup}" if @config.ccgroup %> \
+              <%- else %>
+                  -u <%= @config.user %> -g <%= @config.group %> \
+              <%- end %>
+              -a <%= @config.listen_address %>:<%= @config.listen_port %> \
               -f <%= @config.path_to_vcl %> \
               -T <%= @config.admin_listen_address %>:<%= @config.admin_listen_port %> \
-              -u <%= @config.user %> -g <%= @config.group %> \
               -t <%= @config.ttl %> \
              <%- if node['platform_family'] == 'debian' %>
               -n $INSTANCE \

--- a/templates/default/lib_default.vcl.erb
+++ b/templates/default/lib_default.vcl.erb
@@ -1,4 +1,4 @@
-<%- if @varnish_version == '4' %>
+<%- if @varnish_version >= 4.0 %>
 vcl 4.0;
 <%- end %>
 backend default {

--- a/templates/default/lib_varnishlog.erb
+++ b/templates/default/lib_varnishlog.erb
@@ -20,7 +20,7 @@ DAEMON_OPTS="-a -w $LOGFILE -D -P $PIDFILE \
              <%- if node['platform_family'] == 'debian' %>
               -n $INSTANCE \
              <%- end %>
-	     <%- if @config.log_format == 'varnishncsa' && @varnish_version.to_i > 2 %>
+	     <%- if @config.log_format == 'varnishncsa' && @varnish_major_version.to_i > 2 %>
 	     -F '${LOG_FORMAT}' \
 	     <%- end %>
           "

--- a/templates/default/lib_varnishlog_systemd.erb
+++ b/templates/default/lib_varnishlog_systemd.erb
@@ -5,7 +5,7 @@ After=varnish.service
 [Service]
 Type=forking
 PIDFile=<%= @config.pid %>
-ExecStart=/usr/bin/<%= @config.log_format %> -a -w <%= @config.file_name %> -D -P <%= @config.pid %> -n <%= @config.instance_name || node['hostname'] %> <%- if @config.log_format == 'varnishncsa' && @varnish_version.to_i > 2 %> -F <%= @config.ncsa_format_string %> <%- end %>
+ExecStart=/usr/bin/<%= @config.log_format %> -a -w <%= @config.file_name %> -D -P <%= @config.pid %> -n <%= @config.instance_name || node['hostname'] %> <%- if @config.log_format == 'varnishncsa' && @varnish_major_version.to_i > 2 %> -F <%= @config.ncsa_format_string %> <%- end %>
 
 [Install]
 WantedBy=multi-user.target

--- a/test/fixtures/cookbooks/install_varnish/recipes/custom_vcl_41_install.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/custom_vcl_41_install.rb
@@ -1,0 +1,16 @@
+include_recipe 'apt'
+package 'curl'
+
+varnish_install 'default' do
+  package_name 'varnish'
+  vendor_repo true
+  vendor_version '4.1'
+end
+
+varnish_default_config 'default'
+
+varnish_default_vcl 'default' do
+  vcl_source 'lib_default_custom.vcl.erb'
+  vcl_cookbook 'install_varnish'
+  vcl_parameters(url: '/test_url')
+end

--- a/test/fixtures/cookbooks/install_varnish/recipes/vendor_41_install.rb
+++ b/test/fixtures/cookbooks/install_varnish/recipes/vendor_41_install.rb
@@ -1,0 +1,59 @@
+include_recipe 'apt'
+package 'curl'
+
+varnish_install 'default' do
+  package_name 'varnish'
+  vendor_repo true
+  vendor_version '4.1'
+end
+
+# needed for tests because this directory is not always on created instances
+directory 'logrotate' do
+  path '/etc/logrotate.d'
+  user 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
+varnish_default_config 'default' do
+  start_on_boot true
+  max_open_files 131_072
+  max_locked_memory 82_000
+  listen_address nil
+  listen_port 6081
+  path_to_vcl '/etc/varnish/default.vcl'
+  admin_listen_address '127.0.0.1'
+  admin_listen_port 6082
+  user 'varnish'
+  group 'varnish'
+  ttl 120
+  storage 'malloc'
+  malloc_size "#{(node['memory']['total'][0..-3].to_i * 0.75).to_i}K"
+  parameters(thread_pools: '4',
+             thread_pool_min: '5',
+             thread_pool_max: '500',
+             thread_pool_timeout: '300')
+  path_to_secret '/etc/varnish/secret'
+end
+
+varnish_default_vcl 'default' do
+  backend_host 'rackspace.com'
+  backend_port 80
+end
+
+varnish_log 'default' do
+  file_name '/var/log/varnish/varnishlog.log'
+  pid '/var/run/varnishlog.pid'
+  log_format 'varnishlog'
+  logrotate false
+end
+
+varnish_log 'default_ncsa' do
+  file_name '/var/log/varnish/varnishncsa.log'
+  pid '/var/run/varnishncsa.pid'
+  log_format 'varnishncsa'
+  ncsa_format_string '%h|%l|%u|%t|\"%r\"|%s|%b|\"%{Referer}i\"|\"%{User-agent}i\"'
+  logrotate true
+  logrotate_path '/etc/logrotate.d'
+end

--- a/test/integration/varnish41/serverspec/default_spec.rb
+++ b/test/integration/varnish41/serverspec/default_spec.rb
@@ -1,0 +1,17 @@
+# Encoding: utf-8
+
+require_relative 'spec_helper'
+
+describe service('varnish') do
+  it 'enabled' do
+    expect(subject).to be_enabled
+  end
+  it 'running' do
+    expect(subject).to be_running
+  end
+end
+describe port(6081) do
+  it 'listens on the correct port' do
+    expect(subject).to be_listening
+  end
+end

--- a/test/integration/varnish41/serverspec/spec_helper.rb
+++ b/test/integration/varnish41/serverspec/spec_helper.rb
@@ -1,0 +1,10 @@
+# Encoding: utf-8
+require 'serverspec'
+
+set :backend, :exec
+
+RSpec.configure do |c|
+  c.before :all do
+    c.path = '/sbin:/usr/sbin:/bin:/usr/bin'
+  end
+end

--- a/test/unit/spec/custom_vcl_41_install_spec.rb
+++ b/test/unit/spec/custom_vcl_41_install_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
-describe 'install_varnish::custom_vcl_install' do
-  before { stub_resources('4.0') }
+describe 'install_varnish::custom_vcl_41_install' do
+  before { stub_resources('4.1') }
   let(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: %w(varnish_install
                                            varnish_default_config
@@ -15,8 +15,8 @@ describe 'install_varnish::custom_vcl_install' do
     expect(chef_run).to create_template('/etc/default/varnish')
   end
 
-  it 'creates the varnish default config with the user and group settings set' do
-    expect(chef_run).to render_file('/etc/default/varnish').with_content(/-u varnish -g varnish/)
+  it 'creates the varnish default config with the jail and user settings set' do
+    expect(chef_run).to render_file('/etc/default/varnish').with_content(/-j unix,user=varnish/)
   end
 
   it 'creates the default VCL' do

--- a/test/unit/spec/distro_install_spec.rb
+++ b/test/unit/spec/distro_install_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
 describe 'install_varnish::distro_install' do
-  before { stub_resources }
+  before { stub_resources('4.0') }
   let(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: %w(varnish_install
                                            varnish_default_config

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -19,17 +19,14 @@ def node_resources(node)
   node.set['memory']['total'] = '100000Kb'
 end
 
-def stub_resources
+def stub_resources(version)
   shellout = double
   allow(Mixlib::ShellOut).to receive(:new).with('varnishd -V 2>&1').and_return(shellout)
   allow(shellout).to receive(:run_command).and_return(shellout)
   allow(shellout).to receive(:error!).and_return(true)
-  allow(shellout).to receive(:stdout).and_return('varnish-4.0')
+  allow(shellout).to receive(:stdout).and_return("varnish-#{version}")
   allow(shellout).to receive(:environment).and_return('/root')
   allow(shellout.environment).to receive(:[]=).and_return('/root')
-  allow(shellout.stdout).to receive(:match).and_return(true)
-  allow(shellout.stdout.match).to receive(:captures).and_return(true)
-  allow(shellout.stdout.match.captures).to receive(:[]).and_return(true)
 end
 
 at_exit { ChefSpec::Coverage.report! }

--- a/test/unit/spec/varnish_spec.rb
+++ b/test/unit/spec/varnish_spec.rb
@@ -26,6 +26,7 @@ describe 'debian::varnish::default' do
 end
 
 describe 'varnish without repo installation && without log_deamon' do
+  before { stub_resources('4.0') }
   let(:chef_run) do
     runner = ChefSpec::SoloRunner.new(
       platform: 'debian', version: '7.4'

--- a/test/unit/spec/varnish_spec.rb
+++ b/test/unit/spec/varnish_spec.rb
@@ -1,6 +1,7 @@
 require_relative 'spec_helper'
 
 describe 'debian::varnish::default' do
+  before { stub_resources('4.0') }
   let(:chef_run) do
     runner = ChefSpec::SoloRunner.new(
       platform: 'debian', version: '7.4'

--- a/test/unit/spec/vendor_install_spec.rb
+++ b/test/unit/spec/vendor_install_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
 describe 'install_varnish::vendor_install' do
-  before { stub_resources }
+  before { stub_resources('4.0') }
   let(:chef_run) do
     ChefSpec::SoloRunner.new(step_into: %w(varnish_install
                                            varnish_default_config


### PR DESCRIPTION
Varnish 4.1 replaced -u and -g options with -j, which supports specifying a method for reducing privilege. This add's support for specifying the 'unix' jail method when using 4.1. The change to the cookbook itself is backwards compatible since you need to explicitly upgrade varnish for this to matter, however the group attribute was changed to to ccgroup in this version so this patch reflects that.

The varnish_version helper was also changed to return an array with major and minor versions. Worth noting I wasn't able to run integration test's on CentOS since the box in kitchen.yml doesn't exist any more (would like to rework some of this cookbook so will probably address that in another ticket/pull request). The only changes there though are to varnish_version since the systemd libraries don't  currently support user group.

The Debian varnish-reload script also doesn't support the -j option on varnishd which causes it to exit unsuccessfully, I added a fixed version of reload-vcl to the cookbook to work around it for now. They also seem to have stopped adding the varnishlog group in the 4.1 packaging which causes varnishlog to blow up, so again working around that for now in varnish_install.

